### PR TITLE
Added config option save_dotted_items_as_array

### DIFF
--- a/config/langscanner.php
+++ b/config/langscanner.php
@@ -51,6 +51,11 @@ return [
     | array instead of a flat array. Better for reability and management for large
     | json files
     |
+    | Only use this option if your keys are words or slugs like "page_header" or
+    | "page_header.title". If you use full sentences as keys like "I am error.",
+    | the result json file will be broken because the dot will be changed to an
+    | array.
+    |
     */
     'save_dotted_items_as_array' => false
 ];

--- a/config/langscanner.php
+++ b/config/langscanner.php
@@ -41,4 +41,16 @@ return [
     |
     */
     'excluded_paths' => [],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Save dotted items as array
+    |--------------------------------------------------------------------------
+    |
+    | Uses collect()->undot() to save the items in the JSON files as multi-level
+    | array instead of a flat array. Better for reability and management for large
+    | json files
+    |
+    */
+    'save_dotted_items_as_array' => false
 ];

--- a/src/Commands/LangscannerCommand.php
+++ b/src/Commands/LangscannerCommand.php
@@ -12,7 +12,7 @@ use Illuminate\Filesystem\Filesystem;
 
 class LangscannerCommand extends Command
 {
-    protected $signature = 'langscanner {language?}';
+    protected $signature = 'langscanner {language?} --undot';
     protected $description = "Updates translation files with missing translation keys.";
 
     public function handle(Filesystem $filesystem): void
@@ -23,9 +23,11 @@ class LangscannerCommand extends Command
             $languages = Languages::fromPath(config('langscanner.lang_dir_path'), $filesystem);
         }
 
+        $saveUndotted = $this->option('undot');
+
         foreach ($languages->all() as $language) {
             $fileTranslations = new CachedFileTranslations(
-                new FileTranslations(['language' => $language])
+                new FileTranslations(['language' => $language, 'saveUndotted' => $saveUndotted])
             );
 
             $missingTranslations = new MissingTranslations(

--- a/src/Commands/LangscannerCommand.php
+++ b/src/Commands/LangscannerCommand.php
@@ -12,7 +12,7 @@ use Illuminate\Filesystem\Filesystem;
 
 class LangscannerCommand extends Command
 {
-    protected $signature = 'langscanner {language?} --undot';
+    protected $signature = 'langscanner {language?}';
     protected $description = "Updates translation files with missing translation keys.";
 
     public function handle(Filesystem $filesystem): void
@@ -23,11 +23,9 @@ class LangscannerCommand extends Command
             $languages = Languages::fromPath(config('langscanner.lang_dir_path'), $filesystem);
         }
 
-        $saveUndotted = $this->option('undot');
-
         foreach ($languages->all() as $language) {
             $fileTranslations = new CachedFileTranslations(
-                new FileTranslations(['language' => $language, 'saveUndotted' => $saveUndotted])
+                new FileTranslations(['language' => $language])
             );
 
             $missingTranslations = new MissingTranslations(

--- a/src/FileTranslations.php
+++ b/src/FileTranslations.php
@@ -9,6 +9,7 @@ class FileTranslations implements Contracts\FileTranslations
 {
     private string $language;
     private string $rootPath;
+    private bool $saveUndotted;
     private Filesystem $disk;
 
     public function __construct(array $opts)
@@ -18,6 +19,7 @@ class FileTranslations implements Contracts\FileTranslations
         $this->language = $opts['language'];
         $this->disk = $opts['disk'] ?? resolve(Filesystem::class);
         $this->rootPath = $opts['rootPath'] ?? config('langscanner.lang_dir_path') . '/';
+        $this->saveUndotted = $opts['saveUndotted'] ?? false;
     }
 
     public function language(): string
@@ -28,6 +30,11 @@ class FileTranslations implements Contracts\FileTranslations
     public function update(array $translations): void
     {
         $translations = array_merge($this->all(), $translations);
+
+        if ($this->saveUndotted) {
+            $translations = collect($translations)->undot()->toArray();
+        }
+
         $translations = json_encode($translations, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 
         $this->disk->put($this->path(), $translations);

--- a/src/FileTranslations.php
+++ b/src/FileTranslations.php
@@ -9,7 +9,7 @@ class FileTranslations implements Contracts\FileTranslations
 {
     private string $language;
     private string $rootPath;
-    private bool $saveUndotted;
+    private bool $saveDottedItemsAsArray;
     private Filesystem $disk;
 
     public function __construct(array $opts)
@@ -19,7 +19,7 @@ class FileTranslations implements Contracts\FileTranslations
         $this->language = $opts['language'];
         $this->disk = $opts['disk'] ?? resolve(Filesystem::class);
         $this->rootPath = $opts['rootPath'] ?? config('langscanner.lang_dir_path') . '/';
-        $this->saveUndotted = $opts['saveUndotted'] ?? false;
+        $this->saveDottedItemsAsArray = config('langscanner.save_dotted_items_as_array', false);
     }
 
     public function language(): string
@@ -31,7 +31,7 @@ class FileTranslations implements Contracts\FileTranslations
     {
         $translations = array_merge($this->all(), $translations);
 
-        if ($this->saveUndotted) {
+        if ($this->saveDottedItemsAsArray) {
             $translations = collect($translations)->undot()->toArray();
         }
 


### PR DESCRIPTION
Hi there! I added a config option called "save_dotted_items_as_array" (defaults to false to avoid breaking anything).

Basically, it saved the translations as a multi level array instead of a flat one.

For example, if save_dotted_items_as_array is FALSE, the result would normally be something like:

```
    "api_tokens.header": "API Tokens",
    "api_tokens.title": "Create API Token"
```

If save_dotted_items_as_array is TRUE, the data saved in the JSON would be:

```
    "api_tokens": {
        "header": "API Tokens",
        "title": "Create API Token"
    }
```

Personally, I think it really improves the readability when you have a site with a large amount of lines to manage and translate. 

I hope you find this contribution helpful :)