### PR TITLE
Add the option to pre populate the translation array with defaults

### DIFF
--- a/config/langscanner.php
+++ b/config/langscanner.php
@@ -41,4 +41,14 @@ return [
     |
     */
     'excluded_paths' => [],
+    /*
+    |--------------------------------------------------------------------------
+    | Language of the translation keys
+    |--------------------------------------------------------------------------
+    |
+    | If this is set to some language the translation values for this language
+    | will be the same as the keys instead of empty strings
+    |
+    */
+    'keys_lang'=>'',
 ];

--- a/src/Commands/LangscannerCommand.php
+++ b/src/Commands/LangscannerCommand.php
@@ -35,10 +35,10 @@ class LangscannerCommand extends Command
 
             $fileTranslations->update(
                 // sets translation values to empty string
-                array_fill_keys(
+              config("langscanner.keys_lang") === $language?  array_combine(
                     array_keys($missingTranslations->all()),
-                    ''
-                )
+                    array_keys($missingTranslations->all())
+                ):array_fill_keys(array_keys($missingTranslations->all()),'')
             );
 
             // Render table


### PR DESCRIPTION
Instead of having to translate to each language this will pre populate the translations if the user wants for a one language(The language in which the translation keys are written in)